### PR TITLE
matzekuh patch php7

### DIFF
--- a/action.php
+++ b/action.php
@@ -6,11 +6,11 @@ class action_plugin_doodle3toolbar extends DokuWiki_Action_Plugin {
         /**
          * Register its handlers with the dokuwiki's event controller
          */
-        public function register(Doku_Event_Handler $controller) {
+        public function register(&$controller) {
                 $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array());
         }
 
-        public function insert_button(Doku_Event $event, $param) {
+        public function insert_button(&$event, $param) {
                 $event->data[] = array (
                 'type' => 'insert',
                 'title' => 'doodle3',

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   doodle3toolbar
 author Matthias Jung
 email  matzekuh@web.de
-date   2016-02-01
+date   2016-02-02
 name   Doodle3 Toolbar Plugin
 desc   Toolbar Extension for doodle3
 url    https://www.dokuwiki.org/plugin:doodle3toolbar


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.
