### PR TITLE
update plugin to work with hoghfather release and doodle4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# dokuwiki-plugin-doodle3toolbar
-Dokuwiki action plugin to provide a editor toolbar button for the doodle3 plugin
+# dokuwiki-plugin-doodle4toolbar
+Dokuwiki action plugin to provide a editor toolbar button for the doodle4 plugin
 
 Icons from http://www.famfamfam.com/lab/icons/silk/
 Created by Mark James

--- a/action.php
+++ b/action.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Doodle Plugin 3 Toolbar: adds a toolbar button for easy use of the plugin doodle3
+ * Doodle Plugin 4 Toolbar: adds a toolbar button for easy use of the plugin doodle4
  *
  * @license	GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @url         http://www.dokuwiki.org/plugin:doodle3toolbar
@@ -10,12 +10,12 @@
 
 if (!defined('DOKU_INC')) die();
 
-class action_plugin_doodle3toolbar extends DokuWiki_Action_Plugin {
+class action_plugin_doodle4toolbar extends DokuWiki_Action_Plugin {
 
         /**
          * Register its handlers with the dokuwiki's event controller
          */
-        public function register(&$controller) {
+        public function register(Doku_Event_Handler $controller) {
                 $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array());
         }
         
@@ -25,8 +25,8 @@ class action_plugin_doodle3toolbar extends DokuWiki_Action_Plugin {
         public function insert_button(&$event, $param) {
                 $event->data[] = array (
                 'type' => 'insert',
-                'title' => 'doodle3',
-                'icon' => '../../plugins/doodle3toolbar/icon.png',
+                'title' => 'doodle4',
+                'icon' => '../../plugins/doodle4toolbar/icon.png',
                 'insert' => $this->getConf('inserttext')
                 );
         }

--- a/action.php
+++ b/action.php
@@ -4,8 +4,8 @@
  * Doodle Plugin 4 Toolbar: adds a toolbar button for easy use of the plugin doodle4
  *
  * @license	GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @url         http://www.dokuwiki.org/plugin:doodle3toolbar
- * @author	Matthias Jung <matzekuh@web.de>
+ * @url         http://www.dokuwiki.org/plugin:doodle4toolbar
+ * @author	Matthias Jung <matzekuh@web.de> derpeter <derpeter@c3voc.de>
  */
 
 if (!defined('DOKU_INC')) die();

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,3 @@
 <?php
-$conf['inserttext'] = '<doodle\n  title="TITEL AENDERN"\n  auth="user"\n  adminUsers="testuser"\n  adminGroups=""\n  voteType="multi"\n  closed="false"\n>\n  * Option1\n  * Option2\n</doodle>';
+$conf['inserttext'] = '<doodle\n  title="CHANGE TITLE"\n  auth="user"\n  adminUsers="testuser"\n  adminGroups=""\n  voteType="multi"\n  closed="false"\n>\n  * Option1\n  * Option2\n</doodle>';
 ?>

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
-base   doodle3toolbar
-author Matthias Jung
-email  matzekuh@web.de
-date   2016-02-02
-name   Doodle3 Toolbar Plugin
-desc   Toolbar Extension for doodle3
-url    https://www.dokuwiki.org/plugin:doodle3toolbar
+base   doodle4toolbar
+author Matthias Jung, derpeter
+email  matzekuh@web.de, derpeter@c3voc.de
+date   2020-30-08
+name   Doodle4 Toolbar Plugin
+desc   Toolbar Extension for doodle4
+url    https://www.dokuwiki.org/plugin:doodle4toolbar


### PR DESCRIPTION
As doodle3 is not maintained anymore i renamed the plugin to doodle4 tootlbar.
Also made minimal changes so that the plugin work with latest dokuwiki release.

IMHO it would be good to rename the plugin also in the plugin repository or add it as a new one for doodle4.